### PR TITLE
Add node and edge routers

### DIFF
--- a/src/AppDevEdgeRouter.js
+++ b/src/AppDevEdgeRouter.js
@@ -1,7 +1,6 @@
 // @flow
 import { Request } from 'express';
 import AppDevRouter from './AppDevRouter';
-import type { RequestType } from './constants';
 
 export type Cursor = number
 
@@ -29,18 +28,13 @@ type AppDevEdgesResponse<T> = {
  * type T: The type of nodes returned.
  */
 class AppDevEdgeRouter<T> extends AppDevRouter {
-
-  constructor(type: RequestType) {
-    super(type);
-  }
-
   /** Default number of edges to return */
-  defaultCount() {
-    return 10
+  defaultCount () {
+    return 10;
   }
 
   /** ABSTRACT: the subclass returns an array of edges */
-  async contentArray(
+  async contentArray (
     req: Request,
     pageInfo: PageInfo,
     error: ErrorCollector
@@ -49,14 +43,14 @@ class AppDevEdgeRouter<T> extends AppDevRouter {
   }
 
   /** @return the rendered content */
-  async content(req: Request) {
+  async content (req: Request) {
     const pageInfo = {
       count: req.query.count || this.defaultCount(),
-      cursor: req.query.cursor || undefined,
-    }
+      cursor: req.query.cursor || undefined
+    };
 
-    const errors = []
-    const onerror = err => { errors.push(err) }
+    const errors = [];
+    const onerror = err => { errors.push(err); };
     const edges = await this.contentArray(req, pageInfo, onerror);
 
     const response: AppDevEdgesResponse<T> = {
@@ -64,16 +58,16 @@ class AppDevEdgeRouter<T> extends AppDevRouter {
       pageInfo: {
         count: edges.length
       }
-    }
+    };
 
     if (errors.length) {
       response.errors = errors.map(err => ({
         message: err.message
-      }))
+      }));
     }
 
-    return response
+    return response;
   }
 }
 
-export default AppDevEdgeRouter
+export default AppDevEdgeRouter;

--- a/src/AppDevEdgeRouter.js
+++ b/src/AppDevEdgeRouter.js
@@ -1,0 +1,79 @@
+// @flow
+import { Request } from 'express';
+import AppDevRouter from './AppDevRouter';
+import type { RequestType } from './constants';
+
+export type Cursor = number
+
+export type AppDevEdge<T> = {
+  cursor: Cursor,
+  node: T,
+}
+
+export type PageInfo = {
+  count: number,
+  cursor?: Cursor
+}
+
+export type ResponseError = { message: string }
+
+type ErrorCollector = Error => void
+
+type AppDevEdgesResponse<T> = {
+  edges: Array <AppDevEdge<T>>,
+  errors ?: Array <ResponseError>,
+}
+
+/**
+ * Represents an edge return in a REST API.
+ * type T: The type of nodes returned.
+ */
+class AppDevEdgeRouter<T> extends AppDevRouter {
+
+  constructor(type: RequestType) {
+    super(type);
+  }
+
+  /** Default number of edges to return */
+  defaultCount() {
+    return 10
+  }
+
+  /** ABSTRACT: the subclass returns an array of edges */
+  async contentArray(
+    req: Request,
+    pageInfo: PageInfo,
+    error: ErrorCollector
+  ): Promise<Array<AppDevEdge<T>>> {
+    throw new Error(`Didn't implement contentArray for ${this.getPath()}`);
+  }
+
+  /** @return the rendered content */
+  async content(req: Request) {
+    const pageInfo = {
+      count: req.query.count || this.defaultCount(),
+      cursor: req.query.cursor || undefined,
+    }
+
+    const errors = []
+    const onerror = err => { errors.push(err) }
+    const edges = await this.contentArray(req, pageInfo, onerror);
+
+    const response: AppDevEdgesResponse<T> = {
+      edges,
+      pageInfo: {
+        count: edges.length
+      }
+    }
+
+    if (errors.length) {
+      response.errors = errors.map(err => ({
+        message: err.message
+      }))
+    }
+
+    return response
+  }
+}
+
+export default AppDevEdgeRouter

--- a/src/AppDevNodeRouter.js
+++ b/src/AppDevNodeRouter.js
@@ -1,0 +1,38 @@
+// @flow
+import { Request } from 'express';
+import AppDevRouter from './AppDevRouter';
+import type { RequestType } from './constants';
+
+type id = number
+
+/**
+ * Thin wrapper for fetching nodes. Mainly to ensure format for now.
+ * NOTE: standarizes the use of ":id" as the main entity's id parameter.
+ * (aka, the route needs an :id field)
+ * type T: The type of nodes returned.
+ */
+class AppDevNodeRouter<T> extends AppDevRouter {
+
+  constructor(type: RequestType) {
+    super(type);
+  }
+
+  /** ABSTRACT: the subclass returns an entity */
+  async contentEntity(id: id): Promise<?T> {
+    throw new Error(`Not implemented for path ${this.getPath()}`)
+  }
+
+  /** @return the rendered content */
+  async content(req: Request) {
+
+    const id = parseInt(req.params.id)
+    if (isNaN(id)) throw new Error(`Invalid id ${req.params.id}`)
+
+    const node: ?T = await this.contentEntity(id);
+    if (!node) throw new Error(`Could not fetch id:${req.params.id}`)
+
+    return { node }
+  }
+}
+
+export default AppDevNodeRouter

--- a/src/AppDevNodeRouter.js
+++ b/src/AppDevNodeRouter.js
@@ -1,7 +1,6 @@
 // @flow
 import { Request } from 'express';
 import AppDevRouter from './AppDevRouter';
-import type { RequestType } from './constants';
 
 type id = number
 
@@ -12,27 +11,21 @@ type id = number
  * type T: The type of nodes returned.
  */
 class AppDevNodeRouter<T> extends AppDevRouter {
-
-  constructor(type: RequestType) {
-    super(type);
-  }
-
   /** ABSTRACT: the subclass returns an entity */
-  async contentEntity(id: id): Promise<?T> {
-    throw new Error(`Not implemented for path ${this.getPath()}`)
+  async contentEntity (id: id): Promise<?T> {
+    throw new Error(`Not implemented for path ${this.getPath()}`);
   }
 
   /** @return the rendered content */
-  async content(req: Request) {
-
-    const id = parseInt(req.params.id)
-    if (isNaN(id)) throw new Error(`Invalid id ${req.params.id}`)
+  async content (req: Request) {
+    const id = parseInt(req.params.id);
+    if (isNaN(id)) throw new Error(`Invalid id ${req.params.id}`);
 
     const node: ?T = await this.contentEntity(id);
-    if (!node) throw new Error(`Could not fetch id:${req.params.id}`)
+    if (!node) throw new Error(`Could not fetch id:${req.params.id}`);
 
-    return { node }
+    return { node };
   }
 }
 
-export default AppDevNodeRouter
+export default AppDevNodeRouter;

--- a/src/index.js
+++ b/src/index.js
@@ -1,9 +1,13 @@
 // @flow
 import AppDevRouter from './AppDevRouter';
+import AppDevEdgeRouter from './AppDevEdgeRouter';
+import AppDevNodeRouter from './AppDevNodeRouter';
 
 import appDevUtils from './appDevUtils';
 
 export default {
   AppDevRouter,
-  appDevUtils
+  AppDevEdgeRouter,
+  AppDevNodeRouter,
+  appDevUtils,
 };


### PR DESCRIPTION
RFC

Curious especially on `AppDevNodeRouter.js`. It's really thin atm and requires the path to contain `:id`. Is this sensible?
